### PR TITLE
Use patched version of `showdown-footnotes`

### DIFF
--- a/examples/footnote/instructions.md
+++ b/examples/footnote/instructions.md
@@ -1,0 +1,42 @@
+{.let assignment-title Hands-on 1}
+{.let assignment-due February 6th}
+{.let assignment-intro}
+This is an example to test the footnotes functionality of `mark2html`.
+{./let}
+
+{.let body}
+<!-- Body starts here -->
+
+First footnote[^1].
+
+Second footnote[^2].
+
+<!-- Body ends here -->
+{./let}
+
+<!-- Explorer starts here -->
+{.let explorer-title More to Explore}
+{.let explorer-preface}
+Want to dive deeper into the content covered in this lab? You can explore some related topics here! If not, continue on to checkoff. You don't have to understand stuff we talk about in this section.
+{./let}
+{.let explorer-open Release the kraken}
+{.let explorer-close Hide}
+{.let explorer-footnotes}
+
+[^1]: First footnote content.
+
+[^2]: Second footnote content.
+
+{./let}
+<!-- Explorer ends here -->
+
+{.let submission}
+<!-- Submission info starts here -->
+
+No need to submit anything!
+
+<!-- Submission info ends here -->
+{./let}
+
+
+{.include template-assignment-with-footnotes-v1.md}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@webdesigndecal/showdown-footnotes": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@webdesigndecal/showdown-footnotes/-/showdown-footnotes-2.1.3.tgz",
+            "integrity": "sha512-2aQzagAhGP45awPNOmOcCnhXciquOrt3G45YtSd4E2xfTubuo2eBOGUh4hZ1U6deQJ1UO3LQBL2dKwJnwIVOlA==",
+            "requires": {
+                "showdown": "^1.4.1"
+            }
+        },
         "ansi-regex": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -444,24 +452,6 @@
             "integrity": "sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==",
             "requires": {
                 "yargs": "^10.0.3"
-            }
-        },
-        "showdown-footnotes": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/showdown-footnotes/-/showdown-footnotes-2.1.2.tgz",
-            "integrity": "sha1-3SGZSk4v+rwk6yZqls33dFlQeVw=",
-            "requires": {
-                "showdown": "^1.4.1"
-            },
-            "dependencies": {
-                "showdown": {
-                    "version": "1.9.0",
-                    "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.0.tgz",
-                    "integrity": "sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==",
-                    "requires": {
-                        "yargs": "^10.0.3"
-                    }
-                }
             }
         },
         "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "html-encoder-decoder": "^1.3.6",
         "replace-ext": "^1.0.0",
         "showdown": "^1.7.4",
-        "showdown-footnotes": "^2.1.2"
+        "@webdesigndecal/showdown-footnotes": "^2.1.3"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const path = require("path");
 
 const compressing = require("compressing");
 const showdown = require("showdown");
-const footnotes = require("showdown-footnotes");
+const footnotes = require("@webdesigndecal/showdown-footnotes");
 const replaceExt = require("replace-ext");
 const highlight = require("highlight.js");
 const decodeHTML = require("html-encoder-decoder").decode;


### PR DESCRIPTION
This updates the `showdown-footnotes` dependency with a fork that fixes a parse bug, and supports back linking to the references in text thanks to @jessicamindel.